### PR TITLE
Fix map layer ordering and add zoom constraints

### DIFF
--- a/lib/pages/find_parish_near_me_page.dart
+++ b/lib/pages/find_parish_near_me_page.dart
@@ -144,6 +144,8 @@ class _FindParishNearMePageState extends State<FindParishNearMePage> {
                       options: MapOptions(
                         initialCenter: localUserLocation,
                         initialZoom: 13.0,
+                        minZoom: 8.0,
+                        maxZoom: 18.0,
                       ),
                       children: [
                         TileLayer(
@@ -153,8 +155,8 @@ class _FindParishNearMePageState extends State<FindParishNearMePage> {
                         ),
                         MarkerLayer(
                           markers: [
-                            if (userLocation != null) _buildUserLocationMarker(),
                             ..._buildParishMarkers(),
+                            if (userLocation != null) _buildUserLocationMarker(),
                           ],
                         ),
                       ],


### PR DESCRIPTION
- Move user location marker to end of markers list so it renders on top
- Add minZoom (8.0) and maxZoom (18.0) constraints to prevent excessive zoom
- First test with Claude

Fixes #1