### PR TITLE
Fix sort toggle cycling in FilteredParishListPage

### DIFF
--- a/lib/pages/filtered_parish_list_page.dart
+++ b/lib/pages/filtered_parish_list_page.dart
@@ -169,21 +169,37 @@ class _FilteredParishListPageState extends State<FilteredParishListPage> {
   }
 
   void _applySorting() {
-    if (_sortOrder == SortOrder.distance && widget.userLocation != null) {
-      _filteredParishes.sort((a, b) {
-        final distA = _distances[a.name] ?? double.infinity;
-        final distB = _distances[b.name] ?? double.infinity;
-        return distA.compareTo(distB);
-      });
-    } else if (_sortOrder == SortOrder.nearestAndSoonest && widget.userLocation != null) {
-      // Composite score: combine distance and time
-      _filteredParishes.sort((a, b) {
-        final scoreA = _calculateCompositeScore(a);
-        final scoreB = _calculateCompositeScore(b);
-        return scoreA.compareTo(scoreB);
-      });
-    } else {
-      _filteredParishes.sort((a, b) => a.name.compareTo(b.name));
+    switch (_sortOrder) {
+      case SortOrder.distance:
+        if (widget.userLocation != null && _distances.isNotEmpty) {
+          _filteredParishes.sort((a, b) {
+            final distA = _distances[a.name] ?? double.infinity;
+            final distB = _distances[b.name] ?? double.infinity;
+            return distA.compareTo(distB);
+          });
+        } else {
+          // Fallback to alphabetical if no location data
+          _filteredParishes.sort((a, b) => a.name.compareTo(b.name));
+        }
+        break;
+
+      case SortOrder.nearestAndSoonest:
+        if (widget.userLocation != null && _distances.isNotEmpty && _minutesUntilNext.isNotEmpty) {
+          // Composite score: combine distance and time
+          _filteredParishes.sort((a, b) {
+            final scoreA = _calculateCompositeScore(a);
+            final scoreB = _calculateCompositeScore(b);
+            return scoreA.compareTo(scoreB);
+          });
+        } else {
+          // Fallback to alphabetical if missing data
+          _filteredParishes.sort((a, b) => a.name.compareTo(b.name));
+        }
+        break;
+
+      case SortOrder.alphabetical:
+        _filteredParishes.sort((a, b) => a.name.compareTo(b.name));
+        break;
     }
   }
 
@@ -225,6 +241,7 @@ class _FilteredParishListPageState extends State<FilteredParishListPage> {
           break;
       }
       _applySorting();
+      debugPrint('Sort order toggled to: $_sortOrder');
     });
   }
 


### PR DESCRIPTION
Fixes the sort toggle button to properly cycle through all three modes: Soonest → Nearest → A-Z → Soonest.

## Changes

- Refactored `_applySorting()` to use explicit switch statement
- Added defensive checks for `_distances` and `_minutesUntilNext` maps
- Added debug logging to `_toggleSortOrder()`
- Improved fallback handling for missing location/time data

Resolves #6

---

Generated with [Claude Code](https://claude.ai/code)) • [Branch](https://github.com/mfgarvin/Introibo/tree/claude/issue-6-20260109-0132) • [View job run](https://github.com/mfgarvin/Introibo/actions/runs/20838081480